### PR TITLE
Treat login dialog as a normal form

### DIFF
--- a/src/auth/LoginDialog.js
+++ b/src/auth/LoginDialog.js
@@ -14,7 +14,8 @@ class LoginDialog extends React.Component {
     }
 
     handleChange = event => this.setState({[event.target.id]: event.target.value})
-    handleClick = async () => {
+    handleSubmit = async event => {
+        event.preventDefault()
         const {username, password} = this.state
         const {login, onClose} = this.props
         login(username, password)
@@ -26,30 +27,32 @@ class LoginDialog extends React.Component {
         const {open, onClose} = this.props
         return (
             <Dialog open={open} onClose={onClose}>
-                <DialogTitle>Log in</DialogTitle>
-                <DialogContent>
-                    <TextField
-                        autoFocus
-                        margin='dense'
-                        id='username'
-                        label='Username'
-                        type='text'
-                        fullWidth
-                        onChange={this.handleChange}
-                    />
-                    <TextField
-                        margin='dense'
-                        id='password'
-                        label='Password'
-                        type='password'
-                        fullWidth
-                        onChange={this.handleChange}
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={onClose}>Cancel</Button>
-                    <Button onClick={this.handleClick}>Log in</Button>
-                </DialogActions>
+                <form onSubmit={this.handleSubmit}>
+                    <DialogTitle>Log in</DialogTitle>
+                    <DialogContent>
+                        <TextField
+                            autoFocus
+                            margin='dense'
+                            id='username'
+                            label='Username'
+                            type='text'
+                            fullWidth
+                            onChange={this.handleChange}
+                        />
+                        <TextField
+                            margin='dense'
+                            id='password'
+                            label='Password'
+                            type='password'
+                            fullWidth
+                            onChange={this.handleChange}
+                        />
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={onClose}>Cancel</Button>
+                        <Button type='submit'>Log in</Button>
+                    </DialogActions>
+                </form>
             </Dialog>
         )
     }


### PR DESCRIPTION
Currently, the login dialog requires a click on the `Log in` button because it lacks a `<form>` element, and therefore the `Enter` key has no effect. Wrapping the UI elements in a form should take care of that!

I tested both cases locally (click and enter key) and had success.