### PR TITLE
Use latestchatty.org domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatty",
-  "homepage": "https://latestchatty.github.io/chatty",
+  "homepage": "https://latestchatty.org",
   "version": "0.1.0",
   "license": "MIT",
   "dependencies": {

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+latestchatty.org


### PR DESCRIPTION
I tested it on my fork: http://test.latestchatty.org

I briefly tested it with the root domain on my fork too; HTTPS does work when using the root domain.  Just need to commit this and build/deploy.

Fixes #120 