### PR TITLE
Potential fix for markType sorting issue.

### DIFF
--- a/src/context/chatty/ChattyProvider.js
+++ b/src/context/chatty/ChattyProvider.js
@@ -65,7 +65,7 @@ function ChattyProvider({children}) {
         // sort by activity, pinned first
         nextThreads = nextThreads
             .sort((a, b) => maxPostIdByThread[b.threadId] - maxPostIdByThread[a.threadId])
-            .sort((a, b) => a.markType === b.markType === 'pinned' ? 0 : a.markType === 'pinned' ? -1 : 1)
+            .sort((a, b) => a.markType === b.markType === 'pinned' || a.markType === b.markType !== 'pinned' ? 0 : a.markType === 'pinned' ? -1 : 1)
 
         // update state to trigger render
         setChatty({


### PR DESCRIPTION
The issue is related to the sorting of the markType field on line 68 of ChattyProvider.js. I made an attempt to address the issue but I'm not 100% confident about the logic here and I'm also getting a lint warning that probably shouldn't be ignored (Line 68:  Unexpected mix of '===' and '!=='  no-mixed-operators). That said, the fix does appear to work in both Chrome and Firefox.

If you have any suggestions for addressing the lint warning, let me know, or maybe the condition should be reworked in a different way.